### PR TITLE
Check if the received message has a type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtmhub/sdk",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,12 @@ class Gtmhub {
     window.addEventListener("message", (event) => {
       const { type, data } = event.data;
 
+      // messages can come from different origins, so make sure
+      // we use only expected ones
+      if (!type) {
+        return;
+      }
+
       /** some endpoints doesn't return data (DELETE,PATCH) */
       if (data && data.error) {
         return this.promiseMap[type].reject(data);


### PR DESCRIPTION
When your plugin uses messages on its own, this intercepts with the SDK. I have added a check for `type` and ignore the message otherwise.