### PR TITLE
Handle unexpected and unsupported messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtmhub/sdk",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,58 +1,68 @@
 import axios, { AxiosRequestHeaders } from "axios";
+import {
+  SdkEventType,
+  GtmhubSdkDc,
+  Setting,
+  sdkEventTypes,
+} from "./models";
+const sdkVersion = require("../package.json").version;
 
-type EventType = "linkIssue" | "getCurrentItem" | "updateCurrentItem" | GeneralEvents | PluginEvents | MetricEvents | GoalEvents | TaskEvents | SessionEvents | UserEvents | AccountEvents | TeamEvents;
-type MetricEvents = "getMetrics" | "getMetric" | "createMetric" | "updateMetric" | "deleteMetric" | "checkinMetric" | "patchMetricComment" | "createMetricReaction" | "deleteMetricReaction" | "deleteMetricSnapshot" | "onMetricUpdated";
-type GoalEvents = "getGoal" | "getGoals" | "createGoal" | "updateGoal" | "deleteGoal" | "onGoalUpdated";
-type TaskEvents = "getTask" | "getTasks" | "createTask" | "updateTask" | "deleteTask";
-type UserEvents = "getUser" | "getUsers" | "getCurrentUser" | "createUser" | "updateUser" | "deleteUser";
-type AccountEvents = "getAccountId" | "getAccountUrl" | "getAccountSettings" | "getCustomFields";
-type TeamEvents = "getTeam" | "getTeams" | "createTeam" | "updateTeam" | "deleteTeam";
-type PluginEvents = "getSetting" | "getSettings";
-type SessionEvents = "getSession";
-type GeneralEvents = "getDc" | "resize" | "getAssigneeById" | "getAssigneesByIds";
-type Setting = { key: string; value: string };
+const DEFAULT_GTMUB_SDK_DC = "eu";
 
-type dc = "us" | "eu" | "staging";
 class Gtmhub {
-  pluginId = "";
-  dc;
+  private pluginId = "";
+  private dc: GtmhubSdkDc = DEFAULT_GTMUB_SDK_DC;
 
-  promiseMap: {
+  private promiseMap: {
     [method: string]: {
-      resolve: (value) => void;
-      reject: (reason) => void;
+      resolve(value): void;
+      reject(reason): void;
     };
   } = {};
 
-  callbackMap: {
+  private callbackMap: {
     [method: string]: (payload) => {};
   } = {};
 
   constructor({ pluginId }) {
     this.pluginId = pluginId;
 
-    if (!this.dc) {
-      this.postMessage("getDc").then((dc) => (this.dc = dc));
-    }
+    this.postMessage<GtmhubSdkDc>("getDc").then((dc) => (this.dc = dc));
 
     window.addEventListener("message", (event) => {
       const { type, data } = event.data;
-      const allowedEventTypes = ["onGoalUpdated","onMetricUpdated"];
 
-      // Notify plugin when objective is updated
-      if (allowedEventTypes.indexOf(type) > -1) { 
+      if (!type) {
+        return;
+      }
+
+      const shouldNotifyPluginOnEventTypes = [
+        "onGoalUpdated",
+        "onMetricUpdated",
+      ];
+      if (shouldNotifyPluginOnEventTypes.indexOf(type) > -1) {
         const eventCallback = this.callbackMap[type];
         eventCallback && eventCallback(data);
         return;
       }
 
-      // messages can come from different origins, so make sure
-      // we use only expected ones
-      if (!type) {
-        return;
+      // messages can come from different origins, so make sure:
+      const isMessageTypeSupportedBySdk = sdkEventTypes.includes(type);
+      const isMessageExpected = !!this.promiseMap[type];
+      if (!isMessageExpected) {
+        // 1.) we only respond to supported event types
+        if (!isMessageTypeSupportedBySdk) {
+          this.notifyMessageTypeNotSupported(type);
+          return;
+        }
+        // 2) we only respond to expected event types
+        if (isMessageTypeSupportedBySdk) {
+          this.notifyMessageTypeNotExpected(type);
+          return;
+        }
       }
 
-      /** some endpoints doesn't return data (DELETE,PATCH) */
+      /** some endpoints don't return data (DELETE,PATCH) */
       if (data && data.error) {
         return this.promiseMap[type].reject(data);
       }
@@ -62,73 +72,155 @@ class Gtmhub {
   }
 
   /** METRICS */
-  getMetric = (id: string): Promise<unknown> => this.postMessage("getMetric", { id });
-  getMetrics = (id: string): Promise<unknown> => this.postMessage("getMetrics", { id });
-  deleteMetric = (id: string): Promise<unknown> => this.postMessage("deleteMetric", { id });
-  createMetric = (payload): Promise<unknown> => this.postMessage("createMetric", { payload });
-  updateMetric = (payload): Promise<unknown> => this.postMessage("updateMetric", { payload });
-  checkinMetric = (payload): Promise<unknown> => this.postMessage("checkinMetric", { payload });
-  patchMetricComment = (payload): Promise<unknown> => this.postMessage("patchMetricComment", { payload });
-  createMetricReaction = (payload): Promise<unknown> => this.postMessage("createMetricReaction", { payload });
-  deleteMetricReaction = (payload): Promise<unknown> => this.postMessage("deleteMetricReaction", { payload });
-  deleteMetricSnapshot = (payload): Promise<unknown> => this.postMessage("deleteMetricSnapshot", { payload });
-  onMetricUpdated = (cb: (payload) => {}) => {
+  getMetric = (id: string): Promise<unknown> =>
+    this.postMessage("getMetric", { id });
+  getMetrics = (id: string): Promise<unknown> =>
+    this.postMessage("getMetrics", { id });
+  deleteMetric = (id: string): Promise<unknown> =>
+    this.postMessage("deleteMetric", { id });
+  createMetric = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createMetric", { payload });
+  updateMetric = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("updateMetric", { payload });
+  checkinMetric = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("checkinMetric", { payload });
+  patchMetricComment = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("patchMetricComment", { payload });
+  createMetricReaction = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createMetricReaction", { payload });
+  deleteMetricReaction = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("deleteMetricReaction", { payload });
+  deleteMetricSnapshot = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("deleteMetricSnapshot", { payload });
+  onMetricUpdated = (cb: (payload: Record<string, unknown>) => {}) => {
     this.callbackMap["onMetricUpdated"] = cb;
   };
 
   /** GOALS */
-  getGoal = (id: string): Promise<unknown> => this.postMessage("getGoal", { id });
-  getGoals = (payload): Promise<unknown> => this.postMessage("getGoals", { payload });
-  deleteGoal = (id: string): Promise<unknown> => this.postMessage("deleteGoal", { id });
-  createGoal = (payload): Promise<unknown> => this.postMessage("createGoal", { payload });
-  updateGoal = (payload): Promise<unknown> => this.postMessage("updateGoal", { payload });
-  onGoalUpdated = (cb: (payload) => {}) => {
+  getGoal = (id: string): Promise<unknown> =>
+    this.postMessage("getGoal", { id });
+  getGoals = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("getGoals", { payload });
+  deleteGoal = (id: string): Promise<unknown> =>
+    this.postMessage("deleteGoal", { id });
+  createGoal = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createGoal", { payload });
+  updateGoal = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("updateGoal", { payload });
+  onGoalUpdated = (cb: (payload: Record<string, unknown>) => {}) => {
     this.callbackMap["onGoalUpdated"] = cb;
   };
 
   /** TASKS */
-  getTask = (id: string): Promise<unknown> => this.postMessage("getTask", { id });
-  getTasks = (payload): Promise<unknown> => this.postMessage("getTasks", { payload });
-  deleteTask = (id: string): Promise<unknown> => this.postMessage("deleteTask", { id });
-  createTask = (payload): Promise<unknown> => this.postMessage("createTask", { payload });
-  updateTask = (payload): Promise<unknown> => this.postMessage("updateTask", { payload });
+  getTask = (id: string): Promise<unknown> =>
+    this.postMessage("getTask", { id });
+  getTasks = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("getTasks", { payload });
+  deleteTask = (id: string): Promise<unknown> =>
+    this.postMessage("deleteTask", { id });
+  createTask = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createTask", { payload });
+  updateTask = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("updateTask", { payload });
 
   /** USERS */
-  getUser = (id: string): Promise<unknown> => this.postMessage("getUser", { id });
-  getUsers = (payload): Promise<unknown> => this.postMessage("getUsers", { payload });
+  getUser = (id: string): Promise<unknown> =>
+    this.postMessage("getUser", { id });
+  getUsers = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("getUsers", { payload });
   getCurrentUser = (): Promise<unknown> => this.postMessage("getCurrentUser");
-  deleteUser = (id: string): Promise<unknown> => this.postMessage("deleteUser", { id });
-  createUser = (payload): Promise<unknown> => this.postMessage("createUser", { payload });
-  updateUser = (payload): Promise<unknown> => this.postMessage("updateUser", { payload });
+  deleteUser = (id: string): Promise<unknown> =>
+    this.postMessage("deleteUser", { id });
+  createUser = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createUser", { payload });
+  updateUser = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("updateUser", { payload });
 
   /** TEAMS */
-  getTeam = (id: string): Promise<unknown> => this.postMessage("getTeam", { id });
-  getTeams = (payload): Promise<unknown> => this.postMessage("getTeams", { payload });
-  deleteTeam = (id: string): Promise<unknown> => this.postMessage("deleteTeam", { id });
-  createTeam = (payload): Promise<unknown> => this.postMessage("createTeam", { payload });
-  updateTeam = (payload): Promise<unknown> => this.postMessage("updateTeam", { payload });
+  getTeam = (id: string): Promise<unknown> =>
+    this.postMessage("getTeam", { id });
+  getTeams = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("getTeams", { payload });
+  deleteTeam = (id: string): Promise<unknown> =>
+    this.postMessage("deleteTeam", { id });
+  createTeam = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("createTeam", { payload });
+  updateTeam = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("updateTeam", { payload });
 
   /** SESSIONS */
-  getSession = (id: string): Promise<unknown> => this.postMessage("getSession", { id });
+  getSession = (id: string): Promise<unknown> =>
+    this.postMessage("getSession", { id });
 
   /** SETTINGS */
   getSettings = () => this.postMessage<Setting[]>("getSettings");
   getSetting = (id: string) => this.postMessage<Setting>("getSetting", { id });
 
-  updateCurrentItem = (data: unknown): Promise<unknown> => this.postMessage("updateCurrentItem", data);
+  updateCurrentItem = (data: unknown): Promise<unknown> =>
+    this.postMessage("updateCurrentItem", data);
   getCurrentItem = (): Promise<unknown> => this.postMessage("getCurrentItem");
   linkIssue = (issue): Promise<unknown> => this.postMessage("linkIssue", issue);
 
   getAccountId = (): Promise<string> => this.postMessage("getAccountId");
   getAccountUrl = (): Promise<string> => this.postMessage("getAccountUrl");
-  getAccountSettings = (): Promise<unknown> => this.postMessage("getAccountSettings");
-  getAssigneeById = (id): Promise<unknown> => this.postMessage("getAssigneeById", { id });
-  getAssigneesByIds = (payload): Promise<unknown> => this.postMessage("getAssigneesByIds", { payload });
+  getAccountSettings = (): Promise<unknown> =>
+    this.postMessage("getAccountSettings");
+  getAssigneeById = (id: string): Promise<unknown> =>
+    this.postMessage("getAssigneeById", { id });
+  getAssigneesByIds = (payload: Record<string, unknown>): Promise<unknown> =>
+    this.postMessage("getAssigneesByIds", { payload });
   getCustomFields = (): Promise<unknown> => this.postMessage("getCustomFields");
 
-  resize = (payload: { height: number }): Promise<string> => this.postMessage("resize", { payload });
+    /** CUSTOM SDK ERRORS */
+    onEventTypeNotSupported = (cb: (payload: Record<string, unknown>) => {}) => {
+      this.callbackMap["onEventTypeNotSupported"] = cb;
+    };
+    onEventTypeNotExpected = (cb: (payload: Record<string, unknown>) => {}) => {
+      this.callbackMap["onEventTypeNotExpected"] = cb;
+    };
+  
+    private notifyMessageTypeNotSupported = (messageType: string) => {
+      const payload = {
+        messageType,
+        sdkVersion,
+      };
+  
+      const green = "\x1b[32m";
+      const blue = "\x1b[34m";
+      const reset = "\x1b[0m";
+      const notSupportedMsg = `Event with name '${blue}${messageType}${reset}' is not supported in the current ${blue}${sdkVersion}${reset} SDK version, please upgrade SDK to the latest one.`;
+      console.log(`${green}Gtmhub SDK:${reset} ${notSupportedMsg}`);
+  
+      const eventCallback = this.callbackMap["onEventTypeNotSupported"];
+      eventCallback && eventCallback(payload);
+      this.postMessage("onEventTypeNotSupported", { payload });
+    };
+    private notifyMessageTypeNotExpected = (messageType: string) => {
+      const payload = {
+        messageType,
+      };
+  
+      const green = "\x1b[32m";
+      const blue = "\x1b[34m";
+      const reset = "\x1b[0m";
+      const notSupportedMsg = `Unexpected event with name '${blue}${messageType}${reset}'`;
+      console.log(`${green}Gtmhub SDK:${reset} ${notSupportedMsg}`);
+  
+      const eventCallback = this.callbackMap["onEventTypeNotExpected"];
+      eventCallback && eventCallback(payload);
+      this.postMessage("onEventTypeNotExpected", { payload });
+    };
 
-  request = (options: { url: string; method: "GET" | "POST" | "DELETE" | "PUT" | "PATCH"; params?: Record<string, unknown>; data?: unknown; headers?: AxiosRequestHeaders }): Promise<unknown> => {
+  resize = (payload: { height: number }): Promise<string> =>
+    this.postMessage("resize", { payload });
+
+  request = (options: {
+    url: string;
+    method: "GET" | "POST" | "DELETE" | "PUT" | "PATCH";
+    params?: Record<string, unknown>;
+    data?: unknown;
+    headers?: AxiosRequestHeaders;
+  }): Promise<unknown> => {
     const urlObject = new URL(options.url);
     const newUrl = getProxyUrl(this.dc) + urlObject.pathname;
 
@@ -145,7 +237,7 @@ class Gtmhub {
     });
   };
 
-  postMessage<T>(type: EventType, data?): Promise<T> {
+  postMessage<T>(type: SdkEventType, data?): Promise<T> {
     window.parent.postMessage(
       {
         type,
@@ -168,15 +260,16 @@ class Gtmhub {
   }
 }
 
-const getProxyUrl = (dc: dc) => {
+const getProxyUrl = (dc: GtmhubSdkDc) => {
+  if (dc === "staging") {
+    return "https://plugins.staging.gtmhub.com";
+  }
+
   if (dc === "eu") {
     return "https://plugins.gtmhub.com";
   }
-  if (dc === "us") {
-    return "https://plugins.us.gtmhub.com";
-  }
 
-  return "https://plugins.staging.gtmhub.com";
+  return `https://plugins.${dc}.gtmhub.com`;
 };
 
 export const initialiseSdk = ({ pluginId }) => new Gtmhub({ pluginId });

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,112 @@
+const customSdkErrorEvents = [
+  "onEventTypeNotSupported",
+  "onEventTypeNotExpected",
+];
+export type CustomSdkErrorEvents = typeof customSdkErrorEvents[number];
+
+const generalEvents = [
+  "getDc",
+  "resize",
+  "getAssigneeById",
+  "getAssigneesByIds",
+];
+export type GeneralEvents = typeof generalEvents[number];
+
+const currentItemEvents = ["getCurrentItem", "updateCurrentItem"];
+export type CurrentItemEvents = typeof currentItemEvents[number];
+
+const taskEvents = [
+  "getTask",
+  "getTasks",
+  "createTask",
+  "updateTask",
+  "deleteTask",
+] as const;
+export type TaskEvents = typeof taskEvents[number];
+
+const metricEvents = [
+  "getMetrics",
+  "getMetric",
+  "createMetric",
+  "updateMetric",
+  "deleteMetric",
+  "checkinMetric",
+  "patchMetricComment",
+  "createMetricReaction",
+  "deleteMetricReaction",
+  "deleteMetricSnapshot",
+  "onMetricUpdated",
+];
+export type MetricEvents = typeof metricEvents[number];
+
+const goalEvents = [
+  "getGoal",
+  "getGoals",
+  "createGoal",
+  "updateGoal",
+  "deleteGoal",
+  "onGoalUpdated",
+];
+export type GoalEvents = typeof goalEvents[number];
+
+const sessionEvents = ["getSession"];
+export type SessionEvents = typeof sessionEvents[number];
+
+const pluginEvents = ["getSetting", "getSettings"];
+export type PluginEvents = typeof pluginEvents[number];
+
+const userEvents = [
+  "getUser",
+  "getUsers",
+  "getCurrentUser",
+  "createUser",
+  "updateUser",
+  "deleteUser",
+];
+export type UserEvents = typeof userEvents[number];
+
+const teamEvents = [
+  "getTeam",
+  "getTeams",
+  "createTeam",
+  "updateTeam",
+  "deleteTeam",
+];
+export type TeamEvents = typeof teamEvents[number];
+
+const accountEvents = [
+  "getAccountId",
+  "getAccountUrl",
+  "getAccountSettings",
+  "getCustomFields",
+];
+export type AccountEvents = typeof accountEvents[number];
+
+export type Setting = { key: string; value: string };
+
+export const gtmhubDataCenters = [
+  "eu",
+  "us",
+  "us2",
+  "as",
+  "af",
+  "sa",
+  "au",
+] as const;
+type GtmhubDc = typeof gtmhubDataCenters[number];
+export type GtmhubSdkDc = "staging" | GtmhubDc;
+
+export const sdkEventTypes = [
+  ...customSdkErrorEvents,
+  ...generalEvents,
+  ...currentItemEvents,
+  ...taskEvents,
+  ...metricEvents,
+  ...goalEvents,
+  ...sessionEvents,
+  ...pluginEvents,
+  ...userEvents,
+  ...teamEvents,
+  ...accountEvents,
+] as const;
+export type SdkEventType = typeof sdkEventTypes[number] | "linkIssue";


### PR DESCRIPTION
We need to handle 2 cases - unexpected and unsupported messages - to fix type errors as a result of missing promiseMap entries. 
Added support for 2 new event types:
 -  "onEventTypeNotSupported"
 -  "onEventTypeNotExpected"

Added support for missing DCs